### PR TITLE
Fix adding members to expense not rendering live

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1148,9 +1148,9 @@ btnCloseAddMembersToExpense.addEventListener("click", (e) => {
     })
     localStorage.setItem('groups', JSON.stringify(groupsArr));
     addMembersToExpenseDialog.close();
-    listExpenses.innerHTML = getExpensesHTML(group)
+    listExpenses.innerHTML = getExpensesHTML(groupsArr[selectedGroupIndex])
 	document.querySelector(".balances-expenses-container")?.classList.add("show")
-	renderSelectedGroupInfo(group, listExpenses)
+	renderSelectedGroupInfo(groupsArr[selectedGroupIndex], listExpenses)
 });
 
 // console.log(selectedGroupIndex);


### PR DESCRIPTION
lines 1151 and 1153 replaced 'group' with groupsArr[selectedGroupIndex], now newly added members (to expense) are immediately rendered